### PR TITLE
Issue #4: cassandra-tracing fail to extract traces from Scylla

### DIFF
--- a/cassandra-toolbox/CHANGELOG.md
+++ b/cassandra-toolbox/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+
+## 0.1.5
+
+### cassandra-tracing
+
+#### New Features
+
+- Minimal support has been added for Scylla, which uses a different key structure for columns queried with the `dateOf` operator. This support has been tested with Scylla 1.3 only.
+
+#### Bug Fixes
+
+- Sessions which were skipped due to error were properly recorded, but encountered a bug when their details were printed. Error cases should now have their session ID and error message printed, as intended.
+
+
+## 0.1.4
+
+- Uploaded to public PyPI

--- a/cassandra-toolbox/cassandra-tracing
+++ b/cassandra-toolbox/cassandra-tracing
@@ -132,8 +132,8 @@ def process_sessions(dbsession, time_threshold, tombstone_threshold):
     sessions_cnt = dbsession.execute('SELECT COUNT(*) FROM sessions')
     total_cnt = sessions_cnt[0].count
     current_cnt = 0
-    skipped_null = []
-    skipped_err = []
+    skipped_null = []  # Elements: str
+    skipped_err = []  # Elements: tuple<str, str>
     for sess in sessions:
         current_cnt += 1
         print_update(current_cnt, total_cnt)
@@ -179,7 +179,9 @@ def process_sessions(dbsession, time_threshold, tombstone_threshold):
     print('Total skipped due to error:\t{se}'
           .format(se=len(skipped_err)))
     if skipped_err:
-        print('\t' + '\n\t'.join(skipped_err[0] + '\t' + skipped_err[1]))
+        print('\t' + '\n\t'.join([
+            '{sess}\t{err}'.format(sess=x[0], err=x[1]) for x in skipped_err
+        ]))
     print('\n\n')
     return sorted(output, key=lambda k: k['duration'])
 
@@ -248,7 +250,12 @@ def get_event_info(dbsession, session_id):
             flags.add('T')
 
         if not time_started:
-            time_started = event.dateOf_event_id.isoformat()
+            try:
+                # Cassandra
+                time_started = event.dateOf_event_id.isoformat()
+            except AttributeError:
+                # Scylla
+                time_started = event.system_dateof_event_id.isoformat()
     return (tot_tombstone_cnt, max_tombstone_cnt, time_started, query.strip(),
             ''.join(flags))
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def parse_requirements(filename):
 
 setup(
     name="cassandra-toolbox",
-    version='0.1.4',
+    version='0.1.5',
     author="Knewton Database Team",
     author_email="database@knewton.com",
     license="Apache2",


### PR DESCRIPTION
Changes to cassandra-tracing:
* The traceback quoted in Issue #4 was due to a bug in the code block
  that prints the error messages for any erroring sessions. This has
  been fixed and cleaned up.
* The output block in the issue shows that all traces were reported as
  erroring for Scylla, i.e. Scylla was not supported apart from the
  bug that caused the traceback. This was due to a difference in the
  key naming structure for columns queried using the `dateOf` operator.
  The utility will now try looking for the Cassandra-style key first,
  then try the Scylla-style key if the Cassandra-style key is absent.

General changes:
* Version bump.
* Added a changelog.