### PR TITLE
Fix README markdown for github.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,25 +12,25 @@ Installation
 
 It is preferable to create a virtual environment to install these tools into
 
-.. code:: shell
-
-    pip install virtualenv
-    virtualenv /path/to/your/virtualenv
-    source /path/to/your/virtualenv/bin/activate
+```bash
+pip install virtualenv
+virtualenv /path/to/your/virtualenv
+source /path/to/your/virtualenv/bin/activate
+```
 
 To install the project you can clone this repo and install it directly into your virtual environment, this would get you the latest code
 
-.. code:: shell
-
-    git clone git@github.com:Knewton/cassandra-toolbox.git
-    cd cassandra-toolbox
-    ./setup.py install
+```bash
+git clone git@github.com:Knewton/cassandra-toolbox.git
+cd cassandra-toolbox
+./setup.py install
+```
 
 You can also directly install our package from pip
 
-.. code:: shell
-
-    pip install cassandra-toolbox
+```bash
+pip install cassandra-toolbox
+```
 
 
 Usage
@@ -45,22 +45,25 @@ The cassandra-stat tool shows a real-time feed of how many operations have gone 
 
 This script interfaces with the jolokia jmx-http bridge which must be attached to your Cassandra instances that you plan to run cassandra-stat against.  This is very easy however and not intrustive to Cassandra.
 
-Installing Jolokia is painless.  You first `Link download the JVM agent from their website <https://jolokia.org/download.html>` .  Then you modify your ``cassandra-env.sh`` file to include the following line:
-    JVM_OPTS="$JVM_OPTS -javaagent:<Path To Jolokia JVM Agent Jar>.jar"
+Installing Jolokia is painless.  You first [download the JVM agent from their website](https://jolokia.org/download.html).  Then you modify your ``cassandra-env.sh`` file to include the following line:
+
+```bash
+JVM_OPTS="$JVM_OPTS -javaagent:<Path To Jolokia JVM Agent Jar>.jar"
+```
 
 A restart of the Cassandra instance is required after this modification.
 
 To use cassandra-stat you only need to execute the following local to the Cassandra instance you wish to monitor.  You must have activated the virtual environment that cassandra-toolbox is installed into if you have installed the pacakge into a virtual environment.  The output will look similar to the following:
 
-.. code:: shell
-
-    $cassandra-stat
-    Reads     Ranges    Writes    Reads (99%) ms   Ranges (99%) ms   Writes (99%) ms   Compactions     Flushes    Row Cache Misses     Time    ns
-      1         0        111          91.462            68.81            17.4               0             0              0           20:15:36  total
-      2         4        113           91.4             68.30            17.98              0             0              0           20:15:37  total
-      0         0        117           91.4             68.30            17.17              0             0              0           20:15:38  total
-      0         0         72           91.4             68.30            17.34              0             0              0           20:15:39  total
-      0         2         69           91.4             68.30            17.3               0             0              0           20:15:40  total
+```bash
+$cassandra-stat
+Reads     Ranges    Writes    Reads (99%) ms   Ranges (99%) ms   Writes (99%) ms   Compactions     Flushes    Row Cache Misses     Time    ns
+  1         0        111          91.462            68.81            17.4               0             0              0           20:15:36  total
+  2         4        113           91.4             68.30            17.98              0             0              0           20:15:37  total
+  0         0        117           91.4             68.30            17.17              0             0              0           20:15:38  total
+  0         0         72           91.4             68.30            17.34              0             0              0           20:15:39  total
+  0         2         69           91.4             68.30            17.3               0             0              0           20:15:40  total
+```
 
 The fields that are output are as follows:
 
@@ -103,31 +106,31 @@ cassandra-tracing
 -----------------
 This script facilitates analysis of Cassandra tracing data, which on its own is difficult to draw conclusions from.  Tracing is very useful to look at individual CQL queries in the cqlsh shell, however to get a better idea of your system's behavior it is often useful to sample a percentage of queries, trace them, and save these traces for later.  Cassandra makes this easy to do with nodetool.  You can use the following to set the probability that any cql query (that is coordinated by the cassandra node local to this command) is traced to 0.1%.
 
-.. code:: shell
-
-	$nodetool settraceprobability 0.001
+```bash
+$nodetool settraceprobability 0.001
+```
 
 Note that a value of 1 means every query will be traced.  A trace logs many lines for every query so be careful of setting this value very high.  It is possible that tracing less than 5% of all queries can result in a write workload which is equal in number to the load which it is tracing.
 
 To use cassandra-tracing you only need to execute the following local to the Cassandra instance you wish to investigate the tracing logs of.  You must have activated the virtual environment that cassandra-toolbox is installed into if you have installed the pacakge into a virtual environment.  The output will look similar to the following:
 
-.. code:: shell
+```bash
+$ cassandra-tracing `hostname -I`
+100% Complete: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX|100
 
-	$ cassandra-tracing `hostname -I`
-	100% Complete: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX|100
+Total skipped due to null duration:	0
+Total skipped due to error:	0
 
-	Total skipped due to null duration:	0
-	Total skipped due to error:	0
-
-	175 sessions satisfying criteria.
-	Showing 100 longest running results.
-	Session Id                             Duration (microsecs)    Max Tombstones     Total Tombstones    Flags            Time Started         Query
-	bedd77a0-159e-11e6-af1d-5b2aec1d0944          19696                  32                  32                     2016-05-09T04:30:23.259000  SELECT * FROM system.schema_columnfamilies
-	be941af0-1801-11e6-9deb-25e4276011e4          20569                  0                   0                      2016-05-12T05:24:05.280000  Executing single-partition query on ColumnFamilyA
-	b4c924a0-1565-11e6-af1d-5b2aec1d0944          20905                  32                  32                     2016-05-08T21:42:05.041000  SELECT * FROM system.schema_columnfamilies
-	fdf6fda0-174a-11e6-ace9-39442dcd207a          21056                  0                   0                      2016-05-11T07:35:53.724000  Executing single-partition query on ColumnFamilyB
-	c5f24e80-1751-11e6-af1d-5b2aec1d0944          21397                  0                   0                      2016-05-11T08:24:26.216000  Executing single-partition query on ColumnFamilyB
-	f7670600-183b-11e6-af1d-5b2aec1d0944          21992                  0                   0                      2016-05-12T12:20:51.425000  Executing single-partition query on ColumnFamilyC
+175 sessions satisfying criteria.
+Showing 100 longest running results.
+Session Id                             Duration (microsecs)    Max Tombstones     Total Tombstones    Flags            Time Started         Query
+bedd77a0-159e-11e6-af1d-5b2aec1d0944          19696                  32                  32                     2016-05-09T04:30:23.259000  SELECT * FROM system.schema_columnfamilies
+be941af0-1801-11e6-9deb-25e4276011e4          20569                  0                   0                      2016-05-12T05:24:05.280000  Executing single-partition query on ColumnFamilyA
+b4c924a0-1565-11e6-af1d-5b2aec1d0944          20905                  32                  32                     2016-05-08T21:42:05.041000  SELECT * FROM system.schema_columnfamilies
+fdf6fda0-174a-11e6-ace9-39442dcd207a          21056                  0                   0                      2016-05-11T07:35:53.724000  Executing single-partition query on ColumnFamilyB
+c5f24e80-1751-11e6-af1d-5b2aec1d0944          21397                  0                   0                      2016-05-11T08:24:26.216000  Executing single-partition query on ColumnFamilyB
+f7670600-183b-11e6-af1d-5b2aec1d0944          21992                  0                   0                      2016-05-12T12:20:51.425000  Executing single-partition query on ColumnFamilyC
+```
 
 The output displays the following information, sorted by duration:
 
@@ -144,28 +147,28 @@ The output displays the following information, sorted by duration:
 
 The Session Id can be used to introspect specific queries (which are logged as a session) in cqlsh yourself, by querying for the session id in the events table of the system_tracing keyspace.
 
-.. code:: shell
-
-    $ cqlsh `hostname -I`
-    Connected to cassandra at 172.ip.ip.ip:9042.
-    [cqlsh 5.0.1 | Cassandra 2.1.11 | CQL spec 3.2.1 | Native protocol v3]
-    Use HELP for help.
-    cqlsh> use system_traces;
-    cqlsh:system_traces> select * from events WHERE session_id=bedd77a0-159e-11e6-af1d-5b2aec1d0944;
-    session_id                           | event_id                             | activity                                                                                         | source       | source_elapsed | thread
-    --------------------------------------+--------------------------------------+--------------------------------------------------------------------------------------------------+--------------+----------------+---------------------
-    bedd77a0-159e-11e6-af1d-5b2aec1d0944 | bedd9eb0-159e-11e6-af1d-5b2aec1d0944 |                                               Parsing SELECT * FROM system.schema_columnfamilies | 172.ip.ip.ip |             21 | SharedPool-Worker-2
-    bedd77a0-159e-11e6-af1d-5b2aec1d0944 | beddecd0-159e-11e6-af1d-5b2aec1d0944 |                                                                              Preparing statement | 172.ip.ip.ip |             31 | SharedPool-Worker-2
-    bedd77a0-159e-11e6-af1d-5b2aec1d0944 | bede13e0-159e-11e6-af1d-5b2aec1d0944 |                                                                        Computing ranges to query | 172.ip.ip.ip |             73 | SharedPool-Worker-2
-    bedd77a0-159e-11e6-af1d-5b2aec1d0944 | bede3af0-159e-11e6-af1d-5b2aec1d0944 | Submitting range requests on 1 ranges with a concurrency of 1 (22.37143 rows per range expected) | 172.ip.ip.ip |             88 | SharedPool-Worker-2
-    bedd77a0-159e-11e6-af1d-5b2aec1d0944 | bede6200-159e-11e6-af1d-5b2aec1d0944 |                                          Submitted 1 concurrent range requests covering 1 ranges | 172.ip.ip.ip |             96 | SharedPool-Worker-2
-    bedd77a0-159e-11e6-af1d-5b2aec1d0944 | beded730-159e-11e6-af1d-5b2aec1d0944 |                                      Executing seq scan across 3 sstables for [min(-1), min(-1)] | 172.ip.ip.ip |            382 | SharedPool-Worker-4
-    bedd77a0-159e-11e6-af1d-5b2aec1d0944 | bedefe40-159e-11e6-af1d-5b2aec1d0944 |                                                                Read 7 live and 0 tombstone cells | 172.ip.ip.ip |           2057 | SharedPool-Worker-4
-    bedd77a0-159e-11e6-af1d-5b2aec1d0944 | bedf2550-159e-11e6-af1d-5b2aec1d0944 |                                                                Read 2 live and 0 tombstone cells | 172.ip.ip.ip |           2495 | SharedPool-Worker-4
-    bedd77a0-159e-11e6-af1d-5b2aec1d0944 | bedf7370-159e-11e6-af1d-5b2aec1d0944 |                                                                Read 1 live and 0 tombstone cells | 172.ip.ip.ip |           3066 | SharedPool-Worker-4
-    bedd77a0-159e-11e6-af1d-5b2aec1d0944 | bee00fb0-159e-11e6-af1d-5b2aec1d0944 |                                                              Read 17 live and 32 tombstone cells | 172.ip.ip.ip |          16892 | SharedPool-Worker-4
-    bedd77a0-159e-11e6-af1d-5b2aec1d0944 | bee05dd0-159e-11e6-af1d-5b2aec1d0944 |                                                                Read 7 live and 0 tombstone cells | 172.ip.ip.ip |          18757 | SharedPool-Worker-4
-    bedd77a0-159e-11e6-af1d-5b2aec1d0944 | bee084e0-159e-11e6-af1d-5b2aec1d0944 |                                                                     Scanned 5 rows and matched 5 | 172.ip.ip.ip |          19172 | SharedPool-Worker-4
+```bash
+$ cqlsh `hostname -I`
+Connected to cassandra at 172.ip.ip.ip:9042.
+[cqlsh 5.0.1 | Cassandra 2.1.11 | CQL spec 3.2.1 | Native protocol v3]
+Use HELP for help.
+cqlsh> use system_traces;
+cqlsh:system_traces> select * from events WHERE session_id=bedd77a0-159e-11e6-af1d-5b2aec1d0944;
+session_id                           | event_id                             | activity                                                                                         | source       | source_elapsed | thread
+--------------------------------------+--------------------------------------+--------------------------------------------------------------------------------------------------+--------------+----------------+---------------------
+bedd77a0-159e-11e6-af1d-5b2aec1d0944 | bedd9eb0-159e-11e6-af1d-5b2aec1d0944 |                                               Parsing SELECT * FROM system.schema_columnfamilies | 172.ip.ip.ip |             21 | SharedPool-Worker-2
+bedd77a0-159e-11e6-af1d-5b2aec1d0944 | beddecd0-159e-11e6-af1d-5b2aec1d0944 |                                                                              Preparing statement | 172.ip.ip.ip |             31 | SharedPool-Worker-2
+bedd77a0-159e-11e6-af1d-5b2aec1d0944 | bede13e0-159e-11e6-af1d-5b2aec1d0944 |                                                                        Computing ranges to query | 172.ip.ip.ip |             73 | SharedPool-Worker-2
+bedd77a0-159e-11e6-af1d-5b2aec1d0944 | bede3af0-159e-11e6-af1d-5b2aec1d0944 | Submitting range requests on 1 ranges with a concurrency of 1 (22.37143 rows per range expected) | 172.ip.ip.ip |             88 | SharedPool-Worker-2
+bedd77a0-159e-11e6-af1d-5b2aec1d0944 | bede6200-159e-11e6-af1d-5b2aec1d0944 |                                          Submitted 1 concurrent range requests covering 1 ranges | 172.ip.ip.ip |             96 | SharedPool-Worker-2
+bedd77a0-159e-11e6-af1d-5b2aec1d0944 | beded730-159e-11e6-af1d-5b2aec1d0944 |                                      Executing seq scan across 3 sstables for [min(-1), min(-1)] | 172.ip.ip.ip |            382 | SharedPool-Worker-4
+bedd77a0-159e-11e6-af1d-5b2aec1d0944 | bedefe40-159e-11e6-af1d-5b2aec1d0944 |                                                                Read 7 live and 0 tombstone cells | 172.ip.ip.ip |           2057 | SharedPool-Worker-4
+bedd77a0-159e-11e6-af1d-5b2aec1d0944 | bedf2550-159e-11e6-af1d-5b2aec1d0944 |                                                                Read 2 live and 0 tombstone cells | 172.ip.ip.ip |           2495 | SharedPool-Worker-4
+bedd77a0-159e-11e6-af1d-5b2aec1d0944 | bedf7370-159e-11e6-af1d-5b2aec1d0944 |                                                                Read 1 live and 0 tombstone cells | 172.ip.ip.ip |           3066 | SharedPool-Worker-4
+bedd77a0-159e-11e6-af1d-5b2aec1d0944 | bee00fb0-159e-11e6-af1d-5b2aec1d0944 |                                                              Read 17 live and 32 tombstone cells | 172.ip.ip.ip |          16892 | SharedPool-Worker-4
+bedd77a0-159e-11e6-af1d-5b2aec1d0944 | bee05dd0-159e-11e6-af1d-5b2aec1d0944 |                                                                Read 7 live and 0 tombstone cells | 172.ip.ip.ip |          18757 | SharedPool-Worker-4
+bedd77a0-159e-11e6-af1d-5b2aec1d0944 | bee084e0-159e-11e6-af1d-5b2aec1d0944 |                                                                     Scanned 5 rows and matched 5 | 172.ip.ip.ip |          19172 | SharedPool-Worker-4
+```
 
 The results from ``cassandra-tracing`` can be limited by thresholds on both duration and tombstones, and by and a result cap. The result cap gathers the same number of results but caps the display.  When limited results are displayed the results displayed are always the longest duration events.
 
@@ -192,7 +195,7 @@ Python 2.7 and Python 3.4+ are supported.
 Licenses
 ========
 
-The cassandra-toolbox pacakge is licensed under the MIT license.
+The cassandra-toolbox pacakge is licensed under the Apache 2.0 license.
 
 Issues
 ======


### PR DESCRIPTION
Replace instances of `.. code:: shell` with the more
appropriate ```bash annotations.

Fix the jolokia link.

README says we're using an MIT license, but the actual license
in the repo disagrees.  Change the README to agree with the repo.